### PR TITLE
Fix stale email reports: fall back to fresh HTML when LLM commentary fails

### DIFF
--- a/run_full_scraper.sh
+++ b/run_full_scraper.sh
@@ -133,20 +133,26 @@ fi
 echo ""
 # Step 5b: Generate housing loan HTML with AI LLM commentary
 echo "Step 5b: Generating LLM housing loan commentary (beta)..."
+# Remove any stale commented file from a previous run first, so a failed
+# commentary step can never cause an outdated report to be emailed.
+rm -f bank_comparison_housing_loan_durchblicker_email_commented.html
 python3 llm_housing_commentary.py --input bank_comparison_housing_loan_durchblicker_email.html --output bank_comparison_housing_loan_durchblicker_email_commented.html
 LLM_COMMENT_EXIT=$?
 
 if [ $LLM_COMMENT_EXIT -ne 0 ]; then
     echo "⚠️  Failed to generate LLM housing loan commentary (exit code: $LLM_COMMENT_EXIT)"
+    echo "   Falling back to email report WITHOUT commentary (fresh data)"
+    HOUSING_EMAIL_FILE=bank_comparison_housing_loan_durchblicker_email.html
 else
     echo "✅ LLM housing loan commentary generated!"
+    HOUSING_EMAIL_FILE=bank_comparison_housing_loan_durchblicker_email_commented.html
 fi
 
 echo ""
 
 # Step 6: Send housing loan email report
-echo "Step 6: Sending housing loan email report..."
-python3 send_email_report.py bank_comparison_housing_loan_durchblicker_email_commented.html --type wohnkredit
+echo "Step 6: Sending housing loan email report ($HOUSING_EMAIL_FILE)..."
+python3 send_email_report.py "$HOUSING_EMAIL_FILE" --type wohnkredit
 EMAIL_EXIT=$?
 
 if [ $EMAIL_EXIT -ne 0 ]; then
@@ -223,20 +229,26 @@ fi
 echo ""
 # Step 4b: Generate LLM commentary for consumer loan HTML email
 echo "Step 4b: Generating LLM commentary for consumer loan HTML email..."
+# Remove any stale commented file from a previous run first, so a failed
+# commentary step can never cause an outdated report to be emailed.
+rm -f bank_comparison_consumer_loan_email_commented.html
 python3 llm_consumer_commentary.py --input bank_comparison_consumer_loan_email.html --output bank_comparison_consumer_loan_email_commented.html
 CONSUMER_LLM_COMMENTARY_EXIT=$?
 
 if [ $CONSUMER_LLM_COMMENTARY_EXIT -ne 0 ]; then
     echo "⚠️  Failed to generate LLM commentary for consumer loan email (exit code: $CONSUMER_LLM_COMMENTARY_EXIT)"
+    echo "   Falling back to email report WITHOUT commentary (fresh data)"
+    CONSUMER_EMAIL_FILE=bank_comparison_consumer_loan_email.html
 else
     echo "✅ LLM commentary for consumer loan email generated!"
+    CONSUMER_EMAIL_FILE=bank_comparison_consumer_loan_email_commented.html
 fi
 
 echo ""
 
 # Step 5: Send consumer loan email report
-echo "Step 5: Sending consumer loan email report..."
-python3 send_email_report.py bank_comparison_consumer_loan_email_commented.html --type konsumkredit
+echo "Step 5: Sending consumer loan email report ($CONSUMER_EMAIL_FILE)..."
+python3 send_email_report.py "$CONSUMER_EMAIL_FILE" --type konsumkredit
 CONSUMER_EMAIL_EXIT=$?
 
 if [ $CONSUMER_EMAIL_EXIT -ne 0 ]; then


### PR DESCRIPTION
## Problem

Die versendeten E-Mail-Reports enthielten veraltete Charts, obwohl Datenbank und Web-Report aktuell waren.

**Ursache:** `run_full_scraper.sh` versendet immer `*_email_commented.html`. Schlägt der LLM-Kommentar-Schritt fehl (`llm_housing_commentary.py` / `llm_consumer_commentary.py`), lief die Pipeline mit einer Warnung weiter — und verschickte die auf der Platte liegende `_commented`-Datei **vom letzten erfolgreichen Lauf**, samt der damals eingebetteten Chart-PNGs. Der frisch generierte Report (verifiziert: der Web-Report auf dem Server enthält Datenpunkte bis heute) kam nie im Postfach an.

## Lösung

In beiden Workflows (Wohnkredit + Konsumkredit):

- Die alte `_commented`-Datei wird vor der Neugenerierung gelöscht — eine veraltete Datei kann nie mehr versendet werden
- Schlägt der Kommentar-Schritt fehl, wird stattdessen die **frisch generierte unkommentierte** E-Mail-HTML versendet (Fallback), statt still eine alte Datei zu schicken
- Der Versand-Schritt loggt jetzt, welche Datei verschickt wird

Hinweis: Falls die E-Mails zuletzt ohne AI-Kommentar ankommen, schlägt der LLM-Schritt auf dem Server fehl — Ursache dann im Log von Step 5b prüfen (z. B. `OPENAI_API_KEY`, openai-Paketversion). Mit diesem Fix sind die Daten im Report aber in jedem Fall aktuell.

## Verifikation

- `bash -n run_full_scraper.sh` (Syntax OK)
- Fallback-Logik: bei Exit-Code ≠ 0 wird die unkommentierte Datei gewählt, sonst die kommentierte

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyqAf7Kinf689o5nzx7cXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyqAf7Kinf689o5nzx7cXS)_