### PR TITLE
Harden LLM commentary chain: robust data export, full error logging, openai floor

### DIFF
--- a/db_helper.py
+++ b/db_helper.py
@@ -428,11 +428,14 @@ def get_all_loan_offers(db_path: Path = DB_PATH) -> List[Dict[str, Any]]:
         }
     """
     import re
-    
+
+    # Databases without submitted offers may not have the table yet
+    ensure_loan_offers_table(db_path)
+
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
-    
+
     # Query all loan offers
     cursor.execute("""
         SELECT anbieter, angebotsdatum, fixzinssatz, effektivzinssatz, laufzeit, fileName, fixzinssatz_in_jahren

--- a/llm_consumer_commentary.py
+++ b/llm_consumer_commentary.py
@@ -212,6 +212,8 @@ def main() -> None:
             max_tokens=args.max_tokens,
         )
     except Exception as exc:  # pragma: no cover - CLI feedback
+        import traceback
+        traceback.print_exc()
         raise SystemExit(f"Fehler: {exc}")
 
 

--- a/llm_housing_commentary.py
+++ b/llm_housing_commentary.py
@@ -213,6 +213,8 @@ def main() -> None:
             max_tokens=args.max_tokens,
         )
     except Exception as exc:  # pragma: no cover - CLI feedback
+        import traceback
+        traceback.print_exc()
         raise SystemExit(f"Fehler: {exc}")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ openpyxl==3.1.2
 playwright==1.40.0
 plotly>=5.17.0
 matplotlib>=3.7.0
-openai>=1.3.5
+openai>=1.66.0


### PR DESCRIPTION
## Kontext

Fortsetzung des E-Mail-Staleness-Fixes (#3): Damit der LLM-Kommentar-Schritt gar nicht erst stillschweigend scheitert bzw. seine Ursache sofort sichtbar wird.

## Änderungen

- **`db_helper.py`**: `get_all_loan_offers()` legt die `loan_offers`-Tabelle bei Bedarf an (`ensure_loan_offers_table`), statt den LLM-Datenexport auf Datenbanken ohne eingereichte Angebote mit `no such table: loan_offers` crashen zu lassen (lokal reproduziert und verifiziert)
- **`llm_housing_commentary.py` / `llm_consumer_commentary.py`**: Bei Fehlern wird jetzt der volle Traceback ausgegeben — das Pipeline-Log von Step 5b/4b zeigt damit die echte Ursache statt nur einer Kurzmeldung
- **`requirements.txt`**: `openai>=1.66.0` (erste Version mit der hier verwendeten Responses-API; bisher `>=1.3.5`, was zu alte Installationen zuließ)

## Verifikation

- Export mit fehlender `loan_offers`-Tabelle: legt Tabelle an, liefert JSON mit 27 Marktdaten-Kombinationen und 0 Konkurrenzangeboten (vorher: Crash)
- Fehlerpfad mit ungültigem API-Key getestet: Exit-Code 1, voller Traceback im Log, Responses-API-Aufruf strukturell korrekt (sauberer 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyqAf7Kinf689o5nzx7cXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyqAf7Kinf689o5nzx7cXS)_