### PR TITLE
Fix competitor offer form: hardcoded localhost never worked from a real domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,48 @@ SCREENSHOTS_DIR=/opt/Bankcomparison/screenshots
 
 # Web Server Deployment (optional)
 WEB_ROOT=/var/www/xxx
+
+# Loan Offer API (optional, only needed for the "Konkurrenzangebot erfassen"
+# form on the housing loan web report - see "Loan Offer Form" below)
+OFFER_API_PORT=5001
+OFFER_API_ALLOWED_ORIGIN=https://smartprototypes.net
 ```
+
+## Loan Offer Form (Konkurrenzangebote erfassen)
+
+The housing loan web report includes a form to manually log competitor loan
+offers. It submits to `offer_api.py`, a small Flask API that writes into the
+`loan_offers` table.
+
+That API binds to `127.0.0.1` only and has no authentication, so it is never
+directly reachable from the internet. It must sit behind a reverse proxy on
+the same domain that serves the report, which the form calls via a relative
+URL (`/bankapi/offers` by default, configurable via `OFFER_API_URL` before
+running `generate_housing_loan_html.py`). A hardcoded
+`http://localhost:5001` (the previous behaviour) can never work for a page
+served from a real domain, since "localhost" then refers to the *visitor's*
+machine, not the server.
+
+Setup on the server (`/opt/Bankcomparison`):
+
+1. Run the API as a systemd service so it survives reboots and restarts on
+   failure. A template is at `deploy/offer-api.service` — copy it, adjust
+   paths/user if needed, then:
+   ```bash
+   sudo cp deploy/offer-api.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now offer-api
+   ```
+2. Add a reverse proxy route in the Apache vhost that serves the report
+   (needs `a2enmod proxy proxy_http`). Template at
+   `deploy/apache-bankapi.conf.snippet`:
+   ```bash
+   sudo a2enmod proxy proxy_http
+   # paste the snippet's ProxyPass/ProxyPassReverse lines into the vhost
+   sudo apachectl configtest && sudo systemctl reload apache2
+   ```
+3. Regenerate the report so it embeds the correct form URL:
+   `python3 generate_housing_loan_html.py`.
 
 ## Usage
 

--- a/deploy/apache-bankapi.conf.snippet
+++ b/deploy/apache-bankapi.conf.snippet
@@ -1,0 +1,9 @@
+# Add inside the <VirtualHost *:443> block for smartprototypes.net
+# (the vhost that already serves /Bank_market_overview/). Requires:
+#   a2enmod proxy proxy_http
+
+ProxyPreserveHost On
+
+# /bankapi/offers -> http://127.0.0.1:5001/api/offers (loopback-only Flask app)
+ProxyPass        /bankapi/ http://127.0.0.1:5001/api/
+ProxyPassReverse /bankapi/ http://127.0.0.1:5001/api/

--- a/deploy/offer-api.service
+++ b/deploy/offer-api.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Bank Scraper - Loan Offer API (offer_api.py)
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/Bankcomparison
+EnvironmentFile=/opt/Bankcomparison/.env
+ExecStart=/opt/Bankcomparison/venv/bin/python3 /opt/Bankcomparison/offer_api.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/generate_housing_loan_html.py
+++ b/generate_housing_loan_html.py
@@ -36,6 +36,13 @@ CHART_PNG_PATH = BASE_DIR / os.getenv('HOUSING_LOAN_CHART_PNG_PATH', 'housing_lo
 INDIVIDUAL_OFFERS_CHART_PNG_PATH = BASE_DIR / os.getenv('INDIVIDUAL_OFFERS_CHART_PNG_PATH', 'individual_offers_chart.png')
 SCREENSHOTS_DIR = BASE_DIR / 'screenshots'
 
+# URL the "Angebot erfassen" form on the web report submits to. Defaults to a
+# same-origin relative path so it works wherever the report is hosted, via an
+# Apache/nginx reverse proxy in front of offer_api.py (see README). A
+# hardcoded http://localhost:5001 only ever works when the *viewer's own
+# machine* runs the API, which is never true for a page served from a domain.
+OFFER_API_URL = os.getenv('OFFER_API_URL', '/bankapi/offers')
+
 
 def get_bank_color(anbieter: str) -> str:
     """
@@ -2186,7 +2193,7 @@ def generate_html():
                 const data = Object.fromEntries(formData.entries());
 
                 try {{
-                    const response = await fetch('http://localhost:5001/api/offers', {{
+                    const response = await fetch('{OFFER_API_URL}', {{
                         method: 'POST',
                         headers: {{'Content-Type': 'application/json'}},
                         body: JSON.stringify(data)
@@ -2206,7 +2213,7 @@ def generate_html():
                     }}
                 }} catch (error) {{
                     statusSpan.style.color = '#dc3545';
-                    statusSpan.textContent = '❌ Server nicht erreichbar. Bitte starten Sie den API-Server (python3 offer_api.py)';
+                    statusSpan.textContent = '❌ Server nicht erreichbar. Bitte prüfen, ob der Offer-API-Dienst läuft.';
                 }}
 
                 submitBtn.disabled = false;

--- a/offer_api.py
+++ b/offer_api.py
@@ -22,9 +22,19 @@ except ImportError:
 BASE_DIR = Path(os.getenv('BANKCOMPARISON_BASE_DIR', '/opt/Bankcomparison'))
 DB_PATH = BASE_DIR / os.getenv('HOUSING_LOAN_DB_PATH', 'austrian_banks_housing_loan.db')
 API_PORT = int(os.getenv('OFFER_API_PORT', 5001))
+# Bind to loopback only: this API has no auth, so it must never be reachable
+# directly from the internet. It's meant to sit behind an Apache/nginx
+# reverse proxy (e.g. https://yourdomain/bankapi/ -> 127.0.0.1:5001), which
+# is also the only setup where the web report's relative fetch('/bankapi/...')
+# call resolves to it. Override only for local development.
+API_HOST = os.getenv('OFFER_API_HOST', '127.0.0.1')
+# Origin allowed to call this API via CORS (the domain the report is served
+# from). Same-origin requests through the reverse proxy don't need CORS at
+# all; this only matters if the report HTML is hosted on a different origin.
+ALLOWED_ORIGIN = os.getenv('OFFER_API_ALLOWED_ORIGIN')
 
 app = Flask(__name__)
-CORS(app)  # Allow cross-origin requests for local development
+CORS(app, origins=[ALLOWED_ORIGIN] if ALLOWED_ORIGIN else [])
 
 
 def ensure_loan_offers_table():
@@ -213,11 +223,14 @@ def health_check():
 
 
 if __name__ == '__main__':
-    print(f"[INFO] Starting Offer API Server on port {API_PORT}")
+    print(f"[INFO] Starting Offer API Server on {API_HOST}:{API_PORT}")
     print(f"[INFO] Database: {DB_PATH}")
+    if not ALLOWED_ORIGIN:
+        print("[WARN] OFFER_API_ALLOWED_ORIGIN not set - cross-origin requests are blocked. "
+              "Same-origin requests via the reverse proxy still work.")
 
     # Ensure table exists
     ensure_loan_offers_table()
 
-    # Run the server
-    app.run(host='0.0.0.0', port=API_PORT, debug=False)
+    # Run the server (loopback-only; expose it via a reverse proxy, see README)
+    app.run(host=API_HOST, port=API_PORT, debug=False)


### PR DESCRIPTION
## Problem

Das „Konkurrenzangebot erfassen"-Formular im Wohnkredit-Report postete an eine hartcodierte URL: `http://localhost:5001/api/offers`. Auf einer von einer echten Domain ausgelieferten Seite bedeutet „localhost" immer den Rechner des **Betrachters**, nicht den Server — das Formular konnte für niemanden funktionieren außer für jemanden, der die API zufällig lokal auf dem eigenen Laptop laufen hat. Zusätzlich mischte der Aufruf `http://` in eine `https://`-Seite, was Browser als Mixed Content grundsätzlich blockieren.

Nebenbefund bei der Analyse: `offer_api.py` band auf `0.0.0.0` — also direkt aus dem Internet erreichbar, ganz ohne Authentifizierung, sobald der Port offen wäre — und die CORS-Konfiguration erlaubte Anfragen von jeder beliebigen Seite.

## Lösung

- **`generate_housing_loan_html.py`**: Formular postet jetzt an eine Same-Origin-URL (`OFFER_API_URL`, Standard `/bankapi/offers`), die per Reverse Proxy zu `offer_api.py` geroutet wird
- **`offer_api.py`**: bindet nur noch auf `127.0.0.1` (statt `0.0.0.0`), CORS ist auf eine konfigurierbare Origin beschränkt statt offen für alle
- **`deploy/offer-api.service`** + **`deploy/apache-bankapi.conf.snippet`**: fertige systemd-Unit und Apache-Reverse-Proxy-Vorlage, dokumentiert in einem neuen README-Abschnitt „Loan Offer Form"

## Verifikation

- API lokal mit den neuen Einstellungen gestartet: bindet bestätigt nur auf `127.0.0.1`
- POST `/api/offers` und GET `/api/offers` erfolgreich getestet (Angebot angelegt, gelistet, wieder gelöscht — keine Testdaten verbleiben)
- `generate_housing_loan_html.py` neu ausgeführt: eingebettetes Formular ruft jetzt `fetch('/bankapi/offers')` auf

## Für den Server-Rollout (siehe README)

1. `git pull origin dev`
2. `deploy/offer-api.service` nach `/etc/systemd/system/` kopieren, `systemctl enable --now offer-api`
3. `deploy/apache-bankapi.conf.snippet` in den bestehenden Apache-vhost von smartprototypes.net einfügen (`a2enmod proxy proxy_http`, dann `apachectl configtest && systemctl reload apache2`)
4. Report neu generieren, damit die korrekte Formular-URL eingebettet wird

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyqAf7Kinf689o5nzx7cXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyqAf7Kinf689o5nzx7cXS)_